### PR TITLE
Set cron job to run every hour

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ workflows:
    nightly:
      triggers:
        - schedule:
-           cron: "* * * * *"
+           cron: "0 * * * *"
            filters:
              branches:
                only:


### PR DESCRIPTION
This project is the largest in CircleCI after `user_interface` & `gatekeper` because it runs every minute. 
Do we really need to run it every minute?

Maybe once an hour is enough?